### PR TITLE
Minor Bugfixes

### DIFF
--- a/Pyshock.py
+++ b/Pyshock.py
@@ -76,10 +76,10 @@ class PishockAPI(object):
 
     def vibrate(self, intensity: int, duration: int) -> None:
         """Vibrate the user with the specified intensity and duration.
-        Intensity must be between 0 and 1, duration must be between 0 and 15."""
+        Intensity must be between 0 and 100, duration must be between 0 and 15."""
         # Sanity checks
-        if not 1 <= intensity <= 100:
-            raise ValueError("Intensity must be between 1 and 100")
+        if not 0 <= intensity <= 100:
+            raise ValueError("Intensity must be between 0 and 100")
         if not 0 <= duration <= 15:
             raise ValueError("Duration must be between 0 and 15")
         # Convert intensity to a percentage

--- a/config.py
+++ b/config.py
@@ -4,4 +4,4 @@ api_key = "" # Your api key from the PiShock website
 share_code = "" # Code that you want the alarm to use 
 app_name = "" # What you want to name the app
 test_mode = False  # Set to 'True' if you want to bypass setting an alarm
-snooze_duration = "" # Set in minutes how long you want a snooze. If you don't want a snooze, set to '0'
+snooze_duration =  # Set in minutes how long you want a snooze. If you don't want a snooze, set to '0'


### PR DESCRIPTION
2 bugfixes.

Pyshock.py was checking that the vibration intensity was between 1 and 100, so whenever the vibration was done at 0, the error was raised, despite being valid.

There was a casting issue when doing some comparisons against "snooze_duration" so adjusted the config file to reflect that it should be an integer not a string.